### PR TITLE
remove redundant state, fix box initialisation bug

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,7 +11,6 @@ body,
 body {
   background-color: black;
   color: white;
-  height: 100vh;
   font-family: "Raleway", sans-serif;
   font-weight: 300;
 }
@@ -23,6 +22,7 @@ button {
 
 #main {
   flex-direction: column;
+  padding: 1rem;
 }
 
 .GameContainer {
@@ -92,11 +92,18 @@ button {
 h1 {
   font-size: 3rem;
   margin: 0;
+  text-align: center;
 }
 
-@media screen and (max-width: 414px) {
+@media screen and (max-width: 1280px) {
   .GameContainer {
     width: 220px;
     height: 220px;
   }
 }
+/* @media screen and (max-width: 414px) {
+  .GameContainer {
+    width: 220px;
+    height: 220px;
+  }
+} */

--- a/src/App.js
+++ b/src/App.js
@@ -9,9 +9,7 @@ import "./App.css";
 const App = () => {
   const [gridSize, updateGridSize] = useState(3);
 
-  const [grids, updateGrids] = useState(getGrid(gridSize));
-
-  const [boxes, updateBoxes] = useState(populateBoxes(grids.length));
+  const [boxes, updateBoxes] = useState(populateBoxes(gridSize));
 
   const [selectedColour, updateSelectedColour] = useState("yellow");
 
@@ -63,7 +61,7 @@ const App = () => {
 
   const handleGridChange = (operator) => {
     let newGrid = gridSize;
-    if (newGrid === 12 && operator === "+") return;
+    if (newGrid === 9 && operator === "+") return;
     if (newGrid === 3 && operator === "-") return;
 
     newGrid = operator === "+" ? newGrid + 1 : newGrid - 1;
@@ -71,7 +69,6 @@ const App = () => {
     handleReset();
 
     let newGridRow = getGrid(newGrid);
-    updateGrids(newGridRow);
 
     let resetMoves = moveCount;
     resetMoves = 0;

--- a/src/Components/Boxes.jsx
+++ b/src/Components/Boxes.jsx
@@ -2,22 +2,25 @@ import React from "react";
 import styled from "styled-components";
 
 const Box = styled.div`
-  width: ${props => 85 / props.gridSize}%;
-  height: ${props => 85 / props.gridSize}%;
+  width: ${(props) => 85 / props.gridSize}%;
+  height: ${(props) => 85 / props.gridSize}%;
+  @media (max-width: 1280px) {
+    width: ${(props) => 75 / props.gridSize}%;
+    height: ${(props) => 75 / props.gridSize}%;
+  }
 `;
 
 const Boxes = ({ boxes, gridSize, onHighlight, selectedColour }) => {
-  
   return (
     <div className="GameContainer">
       {boxes.map(({ id, highlight, colour }) => (
         <Box
-        gridSize={gridSize}
-        key={id}
-        onClick={() => onHighlight(id, selectedColour)}
-        className={highlight ? colour : "boxOff"}
+          gridSize={gridSize}
+          key={id}
+          onClick={() => onHighlight(id, selectedColour)}
+          className={highlight ? colour : "boxOff"}
         />
-        ))}
+      ))}
     </div>
   );
 };

--- a/src/jsmodules/Grid.js
+++ b/src/jsmodules/Grid.js
@@ -73,7 +73,7 @@ export const populateBoxes = (gridRowSize) => {
   let grids = getGrid(gridRowSize);
 
   let boxes = [];
-  for (let i = 0; i < gridRowSize; i++) {
+  for (let i = 0; i < gridRowSize * gridRowSize; i++) {
     boxes.push({
       id: i,
       highlight: false,


### PR DESCRIPTION
Fixed a bug where the 3x3 grid upon loading initialised with the wrong 'numbers' values. Also removed redundant 'grids' state as this is now handled by the functions within the Grids.js modulen, and the 'gridSize' state. 